### PR TITLE
upgrade nan to fix node-gyp errors in Electron v20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "robotjs",
       "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "nan": "^2.14.0",
+        "nan": "^2.17.0",
         "prebuild-install": "^6.1.2"
       },
       "devDependencies": {
@@ -1649,9 +1650,9 @@
       "dev": true
     },
     "node_modules/nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
@@ -4317,9 +4318,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
+      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "napi-build-utils": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/octalmage/robotjs",
   "dependencies": {
-    "nan": "^2.14.0",
+    "nan": "^2.17.0",
     "prebuild-install": "^6.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Brings fix from https://github.com/nodejs/nan/pull/943